### PR TITLE
Added warnings for the status of the documents

### DIFF
--- a/authorities/index.html
+++ b/authorities/index.html
@@ -130,7 +130,7 @@
 					<pre>&lt;dc:subject opf:authority="lcsh" opf:term="sj96005632"&gt;Greed&lt;/dc:subject&gt;</pre>
 				</dd>
 
-				<dt id="ndc"><a href="http://www.jla.or.jp/">NDC</a></dt>
+				<dt id="ndc"><a href="https://www.jla.or.jp/committees/bunrui/tabid/187/Default.aspx">NDC</a></dt>
 				<dd>
 					<p>The main Japanese subject scheme.</p>
 					<pre>&lt;dc:subject opf:authority="ndc" opf:term="910"&gt;日本文学&lt;/dc:subject&gt;</pre>

--- a/authorities/index.html
+++ b/authorities/index.html
@@ -36,9 +36,7 @@
 			</div>
 		</header>
 		<div class="warn">
-			<p><strong>WARNING</strong>: This document is OBSOLETE.</p>
-			<p>Subject authorities are defined in an appendix of the 
-				<a href="https://www.w3.org/TR/epub/#sec-authority">EPUB 3 Specification.</a></p>
+			<p><strong>WARNING</strong>: This document is no longer maintained. Change requests will not be accepted.</p>
 		</div>
 		<section id="sotd" class="section">
 			<h2>Status of this Document</h2>
@@ -96,7 +94,7 @@
 					<pre>&lt;dc:subject opf:authority="bisac" opf:term="FIC033000"&gt;FICTION / Westerns&lt;/dc:subject&gt;</pre>
 				</dd>
 
-				<dt id="clc"><a href="http://clc.nlc.gov.cn/">CLC</a></dt>
+				<dt id="clc"><a href="http://clc.nlc.cn/">CLC</a></dt>
 				<dd>
 					<p>The main subject classification scheme used in China.</p>
 					<pre>&lt;dc:subject opf:authority="clc" opf:term="P7"&gt;海洋学&lt;/dc:subject&gt;</pre>
@@ -151,7 +149,7 @@
 					<pre>&lt;dc:subject opf:authority="udc" opf:term="159.97"&gt;Abnormal psychology&lt;/dc:subject&gt;</pre>
 				</dd>
 				
-				<dt id="wgs"><a href="http://info.vlb.de/files/wgsneuversion2_0.pdf">WGS</a></dt>
+				<dt id="wgs"><a href="http://clc.nlc.cn/">WGS</a></dt>
 				<dd>
 					<p>The main German subject scheme for the book supply chain.</p>
 					<pre>&lt;dc:subject opf:authority="wgs" opf:term="951"&gt;Biographien, Autobiographien&lt;/dc:subject&gt;</pre>

--- a/authorities/index.html
+++ b/authorities/index.html
@@ -35,6 +35,11 @@
 				</div>
 			</div>
 		</header>
+		<div class="warn">
+			<p><strong>WARNING</strong>: This document is OBSOLETE.</p>
+			<p>Subject authorities are defined in an appendix of the 
+				<a href="https://www.w3.org/TR/epub/#sec-authority">EPUB 3 Specification.</a></p>
+		</div>
 		<section id="sotd" class="section">
 			<h2>Status of this Document</h2>
 			<p>This document is subject to change at any time. The terms defined herein will never be removed, but may be

--- a/css/registries.css
+++ b/css/registries.css
@@ -10,3 +10,14 @@ div.history {
     margin-top: 2em;
     margin-bottom: 2em
 }
+div.warn {
+	position: fixed;
+    border: 0.15em solid red;
+	padding-left: 1rem;
+    padding-right: 0.5em;
+    background-color: khaki;
+    top: 0.5rem;
+}
+header {
+    padding-top: 5rem;
+}

--- a/identifiers/index.html
+++ b/identifiers/index.html
@@ -36,7 +36,7 @@
 			</div>
 		</header>
 		<div class="warn">
-			<p><strong>WARNING</strong>: This document is OBSOLETE, the registry is currently not maintained.</p>
+			<p><strong>WARNING</strong>: This document is no longer maintained. Change requests will not be accepted.</p>
 		</div>
 		<section id="sotd" class="section">
 			<h2>Status of this Document</h2>

--- a/identifiers/index.html
+++ b/identifiers/index.html
@@ -35,6 +35,9 @@
 				</div>
 			</div>
 		</header>
+		<div class="warn">
+			<p><strong>WARNING</strong>: This document is OBSOLETE, the registry is currently not maintained.</p>
+		</div>
 		<section id="sotd" class="section">
 			<h2>Status of this Document</h2>
 			<p>This document is subject to change at any time. The terms defined herein will never be removed, but may be

--- a/optimizations/index.html
+++ b/optimizations/index.html
@@ -38,7 +38,13 @@
 			</div>
 			
 		</header>
-		
+
+		<div class="warn">
+			<p><strong>WARNING</strong>: This document is OBSOLETE.</p>
+			<p>The W3C EPUB WG maintains the 
+				<a href="https://w3c.github.io/epub-specs/docs/optimized-pubs/">document</a> separately.</p>
+		</div>
+	
 		<section id="sotd" class="section">
 			<h2>Status of this Document</h2>
 			<p>This document is subject to change at any time. The standards defined herein may be deprecated or removed.</p>

--- a/roles/index.html
+++ b/roles/index.html
@@ -32,7 +32,11 @@
 			</div>
 			
 		</header>
-		
+
+		<div class="warn">
+			<p><strong>WARNING</strong>: This document is OBSOLETE, the registry is currently not maintained.</p>
+		</div>
+	
 		<section id="sotd" class="section">
 			<h2>Status of this Document</h2>
 			<p>This document is subject to change at any time. The terms defined herein will never be removed, but may be

--- a/roles/index.html
+++ b/roles/index.html
@@ -34,7 +34,7 @@
 		</header>
 
 		<div class="warn">
-			<p><strong>WARNING</strong>: This document is OBSOLETE, the registry is currently not maintained.</p>
+			<p><strong>WARNING</strong>: This document is no longer maintained. Change requests will not be accepted.</p>
 		</div>
 	
 		<section id="sotd" class="section">

--- a/types/index.html
+++ b/types/index.html
@@ -31,6 +31,9 @@
 				</div>
 			</div>
 		</header>
+		<div class="warn">
+			<p><strong>WARNING</strong>: This document is OBSOLETE, the registry is currently not maintained.</p>
+		</div>
 		
 		<section id="sotd" class="section">
 			<h2>Status of this Document</h2>

--- a/types/index.html
+++ b/types/index.html
@@ -32,7 +32,7 @@
 			</div>
 		</header>
 		<div class="warn">
-			<p><strong>WARNING</strong>: This document is OBSOLETE, the registry is currently not maintained.</p>
+			<p><strong>WARNING</strong>: This document is no longer maintained. Change requests will not be accepted.</p>
 		</div>
 		
 		<section id="sotd" class="section">


### PR DESCRIPTION
Added the obsolete warnings. The authorities' are now part of the EPUB3.3 specification, and the A11y work at the EPUB WG maintains the Optimized Publication Standard (and both of these are referred from the warning box). For the others, there is a simple box saying that the registry is not maintained any more.